### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,66 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  pull_request:
+    types: [review_requested, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync
+      - name: Lint with ruff
+        uses: astral-sh/ruff-action@v1
+      - name: Test
+        run: uv run --frozen -m pytest
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Upload sdist and wheel as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
+          overwrite: true
+
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    # Specify the GitHub Environment to publish to
+    environment:
+      name: pypi
+      url: https://pypi.org/p/txrm2tiff
+    # upload to PyPI and make a release on every tag
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build]
+    permissions:
+      # this permission is mandatory for trusted publishing To PyPI
+      id-token: write
+      # This permission allows the CI to create the release environment
+      contents: write
+
+    steps:
+      # download sdist and wheel from dist job
+      - uses: actions/download-artifact@v4
+      # publish to PyPI using trusted publishing
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - numpy >=1.24.4
     - scipy >=1.3.3
-    - tifffile >=2020.9.30
+    - tifffile >=2022.7.28
     - omexml-dls >=1.1.0
     - olefile >=0.46
     - pillow >=11

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,10 +37,10 @@ test:
   source_files:
     - tests
   requires:
-    - pytest
-    - parameterized
+    - pytest-cov >=6.0.0
+    - parameterized >=0.9.0
   commands:
-    - python -m pytest .
+    - python -m pytest
 
 about:
   home: https://github.com/DiamondLightSource/{{ name }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - tifffile >=2020.9.30
     - omexml-dls >=1.1.0
     - olefile >=0.46
-    - pillow >=5.3, <10.0.0
+    - pillow >=11
     - pywin32  # [win]
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "omexml-dls>=1.1.0",
     "olefile>=0.46",
     "scipy>=1.3.3",
-    "pillow>=5.3,<10.0.0",
+    "pillow>=11",
     "pywin32;platform_system=='Windows'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,5 @@ fail_under = 90
 [dependency-groups]
 dev = [
     "parameterized>=0.9.0",
-    "pytest-cov>=3.0.0",
+    "pytest-cov>=6.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ source = [
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 90
+fail_under = 80
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,5 @@ fail_under = 90
 dev = [
     "parameterized>=0.9.0",
     "pytest-cov>=6.0.0",
+    "ruff>=0.7.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = [
     "readme",
 ]
 dependencies = [
-    "tifffile>=2020.9.30",
+    "tifffile>=2022.7.28",
     "numpy>=1.24.4",
     "omexml-dls>=1.1.0",
     "olefile>=0.46",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,14 @@ txrm2tiff = [
 txrm2tiff = "txrm2tiff.__main__:main"
 
 [tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q --import-mode=importlib --cov=src/txrm2tiff --cov-report=term --cov-report=xml"
+addopts = "-ra -q --import-mode=importlib"
 testpaths = [
     "tests",
+]
+
+[tool.coverage.run]
+source = [
+    "src/txrm2tiff",
 ]
 
 [tool.coverage.report]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-minversion = 6.0
-addopts = -ra -q --import-mode=importlib --cov=src/txrm2tiff --cov-report=term --cov-report=xml
-testpaths =
-    tests

--- a/src/txrm2tiff/__init__.py
+++ b/src/txrm2tiff/__init__.py
@@ -2,3 +2,5 @@ from .info import __version__, __author__, __email__
 
 from .txrm.main import open_txrm
 from .main import convert_and_save
+
+__all__ = (__version__, __author__, __email__, open_txrm, convert_and_save)

--- a/src/txrm2tiff/__main__.py
+++ b/src/txrm2tiff/__main__.py
@@ -2,6 +2,7 @@
 import argparse
 import sys
 import os
+
 if os.name == "nt":
     sys.stdout.reconfigure(encoding="utf-8")
 

--- a/src/txrm2tiff/inspector.py
+++ b/src/txrm2tiff/inspector.py
@@ -1,5 +1,4 @@
 import traceback
-from dataclasses import dataclass
 
 from txrm2tiff.xradia_properties import stream_dtypes
 
@@ -9,8 +8,7 @@ from .xradia_properties import XrmDataTypes
 
 
 class Inspector:
-
-    def __init__(self, txrm:AbstractTxrm):
+    def __init__(self, txrm: AbstractTxrm):
         self.txrm = txrm
         self._output_text = ""
 
@@ -35,9 +33,11 @@ class Inspector:
             num_str = f"{images_taken} images"
         self._output_text += "{0} of type {1} with dimensions: {2}\n".format(
             num_str,
-            self.txrm.image_dtype
-            if self.txrm.image_dtype is None
-            else self.txrm.image_dtype,
+            (
+                self.txrm.image_dtype
+                if self.txrm.image_dtype is None
+                else self.txrm.image_dtype
+            ),
             ", ".join([str(i) for i in self.txrm.image_dims]),
         )
         if self.txrm.shape[::-1] != self.txrm.image_dims:
@@ -127,7 +127,7 @@ class Inspector:
                             )
                             self.inspect_unknown_dtype_stream(key)
                     else:
-                        self._output_text += f"\nUnknown data type. "
+                        self._output_text += "\nUnknown data type. "
                         self.inspect_unknown_dtype_stream(key)
                 else:
                     self._output_text += f"\nStream '{key}' does not exist.\n"

--- a/src/txrm2tiff/txrm/__init__.py
+++ b/src/txrm2tiff/txrm/__init__.py
@@ -1,1 +1,3 @@
 from .main import open_txrm
+
+__all__ = (open_txrm,)

--- a/src/txrm2tiff/txrm/abstract.py
+++ b/src/txrm2tiff/txrm/abstract.py
@@ -206,7 +206,6 @@ class AbstractTxrm(ABC):
                 raise
             logging.error("Error occurred extracting reference image", exc_info=True)
 
-
     def get_reference(self, load: bool = True) -> typing.Optional[np.ndarray]:
         """Get images from file (numpy ndarray with shape [idx, y, x]).
 

--- a/src/txrm2tiff/txrm/annot_mixin.py
+++ b/src/txrm2tiff/txrm/annot_mixin.py
@@ -141,11 +141,10 @@ class AnnotatorMixin:
                 x0, y0 = self._flip_y(
                     (self.output_shape[2] // 50, self.output_shape[1] // 30)
                 )[0]
-                bar_width = int(6 * self.thickness_modifier)
+                bar_width = math.ceil(6 * self.thickness_modifier)
                 # Set up scale bar text:
-                f = ImageFont.truetype(
-                    str(font_path), int(15 * self.thickness_modifier)
-                )
+                font_size = math.ceil(15 * self.thickness_modifier)
+                f = ImageFont.truetype(str(font_path), font_size)
 
                 tmp_bar_length = (
                     self.output_shape[2] / 5.0
@@ -180,7 +179,7 @@ class AnnotatorMixin:
         return False
 
     def _get_thickness(self, stream_stem: str) -> int:
-        return int(
+        return math.ceil(
             self.read_stream(
                 f"{stream_stem}/AnnStrokeThickness", XDT.XRM_DOUBLE, strict=True
             )[0]

--- a/src/txrm2tiff/txrm_functions/__init__.py
+++ b/src/txrm2tiff/txrm_functions/__init__.py
@@ -1,2 +1,24 @@
-from .general import *
-from .images import *
+from .general import (
+    read_stream,
+    get_stream_from_bytes,
+    get_position_dict,
+    get_file_version,
+    get_image_info_dict,
+)
+from .images import (
+    extract_image_dtype,
+    extract_single_image,
+    fallback_image_interpreter,
+)
+
+
+__all__ = (
+    read_stream,
+    get_stream_from_bytes,
+    get_position_dict,
+    get_file_version,
+    get_image_info_dict,
+    extract_image_dtype,
+    extract_single_image,
+    fallback_image_interpreter,
+)

--- a/src/txrm2tiff/utils/file_handler.py
+++ b/src/txrm2tiff/utils/file_handler.py
@@ -74,7 +74,7 @@ def manual_save(
         resolution = [pixels.get_PhysicalSizeX(), pixels.get_PhysicalSizeY()]
         if None not in resolution:  # Check that both have values
             resolution = [1.e7 / (pixel_size)  for pixel_size in resolution]  # Pixels per resolution unit (converted from nm to cm)
-            resolution_unit = tf.TIFF.RESUNIT.CENTIMETER  # Must use CENTIMETER for maximum compatibility
+            resolution_unit = tf.RESUNIT.CENTIMETER  # Must use CENTIMETER for maximum compatibility
             if tf.__version__ >= "2022.7.28":
                 # 2022.7.28: Deprecate third resolution argument on write (use resolutionunit)
                 tiff_kwargs["resolutionunit"] = resolution_unit

--- a/src/txrm2tiff/utils/file_handler.py
+++ b/src/txrm2tiff/utils/file_handler.py
@@ -73,8 +73,12 @@ def manual_save(
         meta_img.set_Name(filepath.name)
         resolution = [pixels.get_PhysicalSizeX(), pixels.get_PhysicalSizeY()]
         if None not in resolution:  # Check that both have values
-            resolution = [1.e7 / (pixel_size)  for pixel_size in resolution]  # Pixels per resolution unit (converted from nm to cm)
-            resolution_unit = tf.RESUNIT.CENTIMETER  # Must use CENTIMETER for maximum compatibility
+            resolution = [
+                1.0e7 / (pixel_size) for pixel_size in resolution
+            ]  # Pixels per resolution unit (converted from nm to cm)
+            resolution_unit = (
+                tf.RESUNIT.CENTIMETER
+            )  # Must use CENTIMETER for maximum compatibility
             if tf.__version__ >= "2022.7.28":
                 # 2022.7.28: Deprecate third resolution argument on write (use resolutionunit)
                 tiff_kwargs["resolutionunit"] = resolution_unit
@@ -100,7 +104,7 @@ def manual_save(
             description=metadata,
             metadata={"axes": "ZYX"},
             software=f"txrm2tiff {__version__}",
-            **tiff_kwargs
+            **tiff_kwargs,
         )
 
 

--- a/src/txrm2tiff/utils/image_processing.py
+++ b/src/txrm2tiff/utils/image_processing.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 import numpy as np
-from numpy.typing import DTypeLike, NDArray
+from numpy.typing import DTypeLike
 
 from .functions import convert_to_int
 

--- a/src/txrm2tiff/utils/logging.py
+++ b/src/txrm2tiff/utils/logging.py
@@ -13,7 +13,7 @@ level_dict = {
     "warning": logging.WARNING,
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
-    }
+}
 
 
 def create_logger(input_level):
@@ -33,4 +33,3 @@ def create_logger(input_level):
     handler.setFormatter(logging_format)
 
     logger.addHandler(handler)
-

--- a/src/txrm2tiff/utils/metadata.py
+++ b/src/txrm2tiff/utils/metadata.py
@@ -1,12 +1,10 @@
 import logging
 import numpy as np
-from oxdls import OMEXML, DO_XYZCT, PT_UINT16, PT_UINT16, PT_FLOAT, PT_DOUBLE
+from oxdls import OMEXML, DO_XYZCT, PT_UINT16, PT_FLOAT, PT_DOUBLE
 
 from ..txrm import abstract
 
 dtype_dict = {"uint16": PT_UINT16, "float32": PT_FLOAT, "float64": PT_DOUBLE}
-
-
 
 
 def create_ome_metadata(txrm: abstract.AbstractTxrm, filename: str = None) -> OMEXML:
@@ -33,7 +31,9 @@ def create_ome_metadata(txrm: abstract.AbstractTxrm, filename: str = None) -> OM
 
     image = ox.image()
     image.set_ID("Image:0")
-    image.set_AcquisitionDate(txrm.datetimes[0].isoformat())  # formatted as: "yyyy-mm-ddThh:mm:ss"
+    image.set_AcquisitionDate(
+        txrm.datetimes[0].isoformat()
+    )  # formatted as: "yyyy-mm-ddThh:mm:ss"
     if filename is not None:
         image.set_Name(filename)
 
@@ -89,7 +89,9 @@ def create_ome_metadata(txrm: abstract.AbstractTxrm, filename: str = None) -> OM
         y_positions = [
             y_positions[0] + (1.0 - 1.0 / mosaic_rows) * (pixel_size * shape[1] / 2.0)
         ]
-        z_positions = [np.mean(np.asarray(z_positions)[valid_idxs])]  # Average Z for a stitched mosaic
+        z_positions = [
+            np.mean(np.asarray(z_positions)[valid_idxs])
+        ]  # Average Z for a stitched mosaic
         # # NOTE: the number of mosaic rows & columns and the pixel size are all written before acquisition but
         # the xy positions are written during, so only the first frame can be relied upon to have an xy
         # position.

--- a/src/txrm2tiff/utils/shortcut_creation.py
+++ b/src/txrm2tiff/utils/shortcut_creation.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 from sys import executable
 
+
 def _get_Windows_home_path():
     home = os.getenv("USERPROFILE")
     if home is None:
@@ -19,8 +20,12 @@ def _get_Windows_home_path():
             return home_path
         except FileNotFoundError:
             pass
-    logging.error("Cannot find valid home path. The following path was found: '%s'", home)
-    raise FileNotFoundError(f"Cannot find valid home path. The following path was found: '{home}''")
+    logging.error(
+        "Cannot find valid home path. The following path was found: '%s'", home
+    )
+    raise FileNotFoundError(
+        f"Cannot find valid home path. The following path was found: '{home}''"
+    )
 
 
 def _create_lnk_file(shortcut_path):
@@ -61,6 +66,9 @@ def create_Windows_shortcut():
             logging.info("The existing shortcut will not be modified.")
             return
         else:
-            logging.info("Invalid input: %s. The existing shortcut will not be modified.", user_input)
+            logging.info(
+                "Invalid input: %s. The existing shortcut will not be modified.",
+                user_input,
+            )
             return
     _create_lnk_file(shortcut_path)

--- a/src/txrm2tiff/xradia_properties/__init__.py
+++ b/src/txrm2tiff/xradia_properties/__init__.py
@@ -1,2 +1,27 @@
-from .enums import *
-from .stream_dtypes import *
+from .enums import AnnotationTypes, IntValueEnum, XrmDataTypes
+from .stream_dtypes import (
+    alignment_dict,
+    annotations_dict,
+    dtypes_dict,
+    image_info_dict,
+    position_info_dict,
+    ref_image_info_dict,
+    reference_data_dict,
+    misc_dict,
+    streams_dict,
+)
+
+__all__ = (
+    "AnnotationTypes",
+    "IntValueEnum",
+    "XrmDataTypes",
+    "alignment_dict",
+    "annotations_dict",
+    "dtypes_dict",
+    "image_info_dict",
+    "position_info_dict",
+    "ref_image_info_dict",
+    "reference_data_dict",
+    "misc_dict",
+    "streams_dict",
+)

--- a/src/txrm2tiff/xradia_properties/enums.py
+++ b/src/txrm2tiff/xradia_properties/enums.py
@@ -37,6 +37,7 @@ class IntValueEnum(int, enum.Enum):
 
 class XrmDataTypes(IntValueEnum):
     """Integer Enumerator for Xradia's XrmDataTypes"""
+
     # XRM_BIT = None, 1
     XRM_CHAR = np.int8, 2
     XRM_UNSIGNED_CHAR = np.uint8, 3

--- a/src/txrm2tiff/xradia_properties/stream_dtypes.py
+++ b/src/txrm2tiff/xradia_properties/stream_dtypes.py
@@ -38,9 +38,7 @@ image_info_dict = {
     "ImageInfo/ZonePlateName": XrmDataTypes.XRM_STRING,
 }
 
-reference_data_dict = {
-    "ReferenceData/ExpTime": XrmDataTypes.XRM_FLOAT
-    }
+reference_data_dict = {"ReferenceData/ExpTime": XrmDataTypes.XRM_FLOAT}
 
 ref_image_info_dict = {f"ReferenceData/{k}": v for k, v in image_info_dict.items()}
 
@@ -66,11 +64,11 @@ alignment_dict = {
     "Alignment/ReferenceShiftsApplied": XrmDataTypes.XRM_INT,
     "Alignment/StageShiftsApplied": XrmDataTypes.XRM_INT,
     "Alignment/StaticRunoutApplied": XrmDataTypes.XRM_INT,
-    "Alignment/X-Shifts": XrmDataTypes.XRM_FLOAT, # Pixels
-    "Alignment/Y-Shifts": XrmDataTypes.XRM_FLOAT, # Pixels
+    "Alignment/X-Shifts": XrmDataTypes.XRM_FLOAT,  # Pixels
+    "Alignment/Y-Shifts": XrmDataTypes.XRM_FLOAT,  # Pixels
 }
 
-misc = {"exeVersion": XrmDataTypes.XRM_STRING}
+misc_dict = {"exeVersion": XrmDataTypes.XRM_STRING}
 
 streams_dict = {}
 streams_dict.update(image_info_dict)
@@ -80,4 +78,4 @@ streams_dict.update(dtypes_dict)
 streams_dict.update(annotations_dict)
 streams_dict.update(position_info_dict)
 streams_dict.update(alignment_dict)
-streams_dict.update(misc)
+streams_dict.update(misc_dict)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import unittest
 
+
 def runall():
     # Includes integration tests
-    suite = unittest.TestLoader().discover('.', pattern='test_*.py')
-    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    suite = unittest.TestLoader().discover(".", pattern="test_*.py")
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_abstract_txrm.py
+++ b/tests/test_abstract_txrm.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_equal
 
 import numpy as np
 
-from txrm2tiff.txrm.abstract import AbstractTxrm, txrm_property
+from txrm2tiff.txrm.abstract import AbstractTxrm
 from txrm2tiff.xradia_properties.enums import XrmDataTypes
 
 
@@ -154,23 +154,12 @@ class AbstractTxrmTest(unittest.TestCase):
         self.assertEqual(output, img)
 
     @patch("txrm2tiff.txrm.abstract.AbstractTxrm.get_images")
-    def test_get_single_image_is_loaded(self, mocked_get_images):
-        txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
-        img = "test_img"
-        images = [img]
-        mocked_get_images.return_value = images
-        output = txrm.get_single_image(1)
-        mocked_get_images.assert_called_once_with(load=False)
-        self.assertEqual(output, img)
-
-    @patch("txrm2tiff.txrm.abstract.AbstractTxrm.get_images")
     @patch("txrm2tiff.txrm.abstract.AbstractTxrm._extract_single_image")
     def test_get_single_image_is_not_loaded(
         self, mocked_extract_single, mocked_get_images
     ):
         txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
         img = "test_img"
-        images = [img]
         mocked_extract_single.return_value = img
         mocked_get_images.return_value = None
         output = txrm.get_single_image(1)
@@ -192,7 +181,9 @@ class AbstractTxrmTest(unittest.TestCase):
 
         mocked_frombytes.return_value = "output"
         output = txrm.extract_reference_data()
-        mocked_frombytes.assert_called_once_with("ref_data", dtype=txrm.reference_dtype.value)
+        mocked_frombytes.assert_called_once_with(
+            "ref_data", dtype=txrm.reference_dtype.value
+        )
         self.assertEqual(output, "output")
 
     @patch("txrm2tiff.txrm.abstract.AbstractTxrm.has_reference", new=True)
@@ -234,17 +225,26 @@ class AbstractTxrmTest(unittest.TestCase):
         txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
         self.assertEqual(txrm.output_shape, [1, 7 * 3, 6 * 2])
 
-    @patch("txrm2tiff.txrm.abstract.AbstractTxrm.image_info", new={"Date": ["ksfs$oio12/30/2021 23:55:59!j#f"]})
+    @patch(
+        "txrm2tiff.txrm.abstract.AbstractTxrm.image_info",
+        new={"Date": ["ksfs$oio12/30/2021 23:55:59!j#f"]},
+    )
     def test_datetimes(self):
         txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
         self.assertEqual(txrm.datetimes[0], datetime(2021, 12, 30, 23, 55, 59))
 
-    @patch("txrm2tiff.txrm.abstract.AbstractTxrm.image_info", new={"Date": ["ksfs$oio12/30/21 23:55:59!j#f"]})
+    @patch(
+        "txrm2tiff.txrm.abstract.AbstractTxrm.image_info",
+        new={"Date": ["ksfs$oio12/30/21 23:55:59!j#f"]},
+    )
     def test_datetimes_without_century(self):
         txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
         self.assertEqual(txrm.datetimes[0], datetime(2021, 12, 30, 23, 55, 59))
 
-    @patch("txrm2tiff.txrm.abstract.AbstractTxrm.image_info", new={"Date": ["ksfs$oio12/30/2021 23:55:59.83!j#f"]})
+    @patch(
+        "txrm2tiff.txrm.abstract.AbstractTxrm.image_info",
+        new={"Date": ["ksfs$oio12/30/2021 23:55:59.83!j#f"]},
+    )
     def test_datetimes_with_milliseconds(self):
         txrm = AbstractTxrm("test/path", load_images=False, load_reference=False)
         self.assertEqual(txrm.datetimes[0], datetime(2021, 12, 30, 23, 55, 59, 830000))

--- a/tests/test_commandline_entrypoint.py
+++ b/tests/test_commandline_entrypoint.py
@@ -21,7 +21,7 @@ class TestCommandlineEntryPoint(unittest.TestCase):
     def setUpClass(cls):
         # Set maximum difference string length to None (infinite)
         cls.maxDiff = None
-        # Add local intall to path for testing with development install
+        # Add local install to path for testing with development install
         if os.name == "posix":
             os.environ["PATH"] += os.pathsep + os.path.join(
                 os.path.expanduser("~"), ".local", "bin"
@@ -125,7 +125,7 @@ class TestCommandlineEntryPoint(unittest.TestCase):
         with Popen(run_args, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as p:
             stdout, _ = p.communicate()
         # Get the last line (ignore the input)
-        stdout = [l.strip() for l in stdout.strip("\n").split("\n")][-1]
+        stdout = [_.strip() for _ in stdout.strip("\n").split("\n")][-1]
         self.assertEqual(
             f"txrm2tiff {__version__}", stdout, msg=f"Actual stdout: {stdout}"
         )
@@ -154,7 +154,6 @@ class TestCommandlineEntryPoint(unittest.TestCase):
 
     def test_module_without_arguments_returns_help(self):
         run_args = [sys.executable, "-m", "txrm2tiff"]
-        path = os.environ["PATH"]
         with Popen(run_args, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as p:
             stdout, _ = p.communicate()
         stdout = stdout.strip("\r\n").strip("\n")
@@ -241,7 +240,7 @@ class TestCommandlineEntryPoint(unittest.TestCase):
         with Popen(run_args, stdout=PIPE, stderr=STDOUT, universal_newlines=True) as p:
             stdout, _ = p.communicate()
         # Get the last line (ignore the input)
-        stdout = [l.strip() for l in stdout.strip("\n").split("\n")][-1]
+        stdout = [_.strip() for _ in stdout.strip("\n").split("\n")][-1]
         self.assertEqual(
             f"txrm2tiff {__version__}", stdout, msg=f"Actual stdout: {stdout}"
         )
@@ -252,5 +251,5 @@ class TestCommandlineEntryPoint(unittest.TestCase):
             stdout, _ = p.communicate()
         stdout = stdout.strip("\r\n").strip("\n")
         self.assertIn(
-            f"txrm2tiff setup [-w] [-h]", stdout, msg=f"Actual stdout: {stdout}"
+            "txrm2tiff setup [-w] [-h]", stdout, msg=f"Actual stdout: {stdout}"
         )

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch, MagicMock
 
 from pathlib import Path
 from datetime import datetime
@@ -125,13 +124,13 @@ class TestFileHandler(unittest.TestCase):
             self.assertTrue(im_path.exists())
             with tf.TiffFile(im_path) as tiff:
                 saved_arr = tiff.asarray()
-                x_resolution = tiff.pages[0].tags['XResolution'].value
-                y_resolution = tiff.pages[0].tags['YResolution'].value
-                resolution_unit = tiff.pages[0].tags['ResolutionUnit'].value
+                x_resolution = tiff.pages[0].tags["XResolution"].value
+                y_resolution = tiff.pages[0].tags["YResolution"].value
+                resolution_unit = tiff.pages[0].tags["ResolutionUnit"].value
 
         assert_array_equal(saved_arr, image)
-        self.assertEqual(x_resolution, (int(1.e7), 1))
-        self.assertEqual(y_resolution, (int(5.e6), 1))
+        self.assertEqual(x_resolution, (int(1.0e7), 1))
+        self.assertEqual(y_resolution, (int(5.0e6), 1))
         self.assertEqual(resolution_unit, int(tf.RESUNIT.CENTIMETER))
 
     def test_manual_annotation_save(self):

--- a/tests/test_file_handler.py
+++ b/tests/test_file_handler.py
@@ -132,8 +132,7 @@ class TestFileHandler(unittest.TestCase):
         assert_array_equal(saved_arr, image)
         self.assertEqual(x_resolution, (int(1.e7), 1))
         self.assertEqual(y_resolution, (int(5.e6), 1))
-        self.assertEqual(resolution_unit, int(tf.TIFF.RESUNIT.CENTIMETER))
-
+        self.assertEqual(resolution_unit, int(tf.RESUNIT.CENTIMETER))
 
     def test_manual_annotation_save(self):
         with TemporaryDirectory(

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,6 +1,5 @@
 from random import randint
 import unittest
-from unittest.mock import MagicMock, patch
 from numpy.testing import (
     assert_array_equal,
     assert_array_almost_equal,
@@ -21,8 +20,6 @@ class TestImageProcessing(unittest.TestCase):
     def test_stitch_mosaic(self):
         mosaic_xy_shape = (3, 4)
         image_size = (400, 400)
-        fast_axis = 1
-        slow_axis = 1 - fast_axis
         images = np.zeros(
             (
                 mosaic_xy_shape[0] * mosaic_xy_shape[1],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,12 +40,6 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(NameError):
             _set_output_suffix(Path("file.bad_extension"), None)
 
-    def test_set_output_suffix(self):
-        txrm_output = _set_output_suffix(Path("file.txrm"))
-        xrm_output = _set_output_suffix(Path("file.xrm"))
-        self.assertEqual("file.ome.tiff", str(txrm_output))
-        self.assertEqual("file.ome.tiff", str(xrm_output))
-
     @parameterized.expand([(Txrm3,), (Txrm5,)])
     @patch("txrm2tiff.main.open_txrm")
     def test_convert_and_save(self, TxrmClass, mocked_open_txrm):
@@ -363,7 +357,15 @@ class TestRun(unittest.TestCase):
         logging_level = "debug"
 
         convert_and_save(
-            input_path, output_path, None, True, False, dtype, True, False, logging_level
+            input_path,
+            output_path,
+            None,
+            True,
+            False,
+            dtype,
+            True,
+            False,
+            logging_level,
         )
 
         mocked_create_logger.assert_called_once_with(logging_level)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 import unittest
-from unittest.mock import patch, MagicMock
-
-import numpy as np
+from unittest.mock import MagicMock
 
 from txrm2tiff.utils.metadata import create_ome_metadata
 

--- a/tests/test_shifts.py
+++ b/tests/test_shifts.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from numpy.testing import assert_array_equal
 
 import numpy as np

--- a/tests/test_with_files.py
+++ b/tests/test_with_files.py
@@ -37,6 +37,7 @@ test_files = [
     (xm10_path / "Xray_mosaic_F5A.xrm",),
 ]
 
+
 @unittest.skipUnless(visit_path.exists(), "dls paths cannot be accessed")
 class TestTxrm2TiffWithFiles(unittest.TestCase):
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -204,35 +204,69 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "9.5.0"
+version = "11.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/d5/4903f310765e0ff2b8e91ffe55031ac6af77d982f0156061e20a4d1a8b2d/Pillow-9.5.0.tar.gz", hash = "sha256:bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1", size = 50488147 }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/26/0d95c04c868f6bdb0c447e3ee2de5564411845e36a858cfd63766bc7b563/pillow-11.0.0.tar.gz", hash = "sha256:72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739", size = 46737780 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/cff591742feea45f88a3b8a83f7cab4a1dcdb4bcdfc51a06d92f96c81165/Pillow-9.5.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:ace6ca218308447b9077c14ea4ef381ba0b67ee78d64046b3f19cf4e1139ad16", size = 3395758 },
-    { url = "https://files.pythonhosted.org/packages/38/06/de304914ecd2c911939a28579546bd4d9b6ae0b3c07ce5fe9bd7d100eb34/Pillow-9.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d3d403753c9d5adc04d4694d35cf0391f0f3d57c8e0030aac09d7678fa8030aa", size = 3077111 },
-    { url = "https://files.pythonhosted.org/packages/9a/57/7864b6a22acb5f1d4b70af8c92cbd5e3af25f4d5869c24cd8074ca1f3593/Pillow-9.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ba1b81ee69573fe7124881762bb4cd2e4b6ed9dd28c9c60a632902fe8db8b38", size = 3112529 },
-    { url = "https://files.pythonhosted.org/packages/62/88/46a35f690ee4f8b08aef5fdb47f63d29c34f6874834155e52bf4456d9566/Pillow-9.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe7e1c262d3392afcf5071df9afa574544f28eac825284596ac6db56e6d11062", size = 3386670 },
-    { url = "https://files.pythonhosted.org/packages/59/1d/26a56ed1deae695a8c7d13fb514284ba8b9fd62bab9ebe6d6b474523b8b0/Pillow-9.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f36397bf3f7d7c6a3abdea815ecf6fd14e7fcd4418ab24bae01008d8d8ca15e", size = 3308572 },
-    { url = "https://files.pythonhosted.org/packages/d4/36/d22b0fac821a14572fdb9a8015b2bf19ee81eaa560ea25a6772760c86a30/Pillow-9.5.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:252a03f1bdddce077eff2354c3861bf437c892fb1832f75ce813ee94347aa9b5", size = 3163999 },
-    { url = "https://files.pythonhosted.org/packages/25/6b/d3c35d207c9c0b6c2f855420f62e64ef43d348e8c797ad1c32b9f2106a19/Pillow-9.5.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:85ec677246533e27770b0de5cf0f9d6e4ec0c212a1f89dfc941b64b21226009d", size = 3415623 },
-    { url = "https://files.pythonhosted.org/packages/7a/6a/a7df39c502caeadd942d8bf97bc2fdfc819fbdc7499a2ab05e7db43611ac/Pillow-9.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b416f03d37d27290cb93597335a2f85ed446731200705b22bb927405320de903", size = 3350658 },
-    { url = "https://files.pythonhosted.org/packages/2e/ad/d29c8c48498da680521665b8483beb78a9343269bbd0730970e9396b01f0/Pillow-9.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1781a624c229cb35a2ac31cc4a77e28cafc8900733a864870c49bfeedacd106a", size = 3414574 },
-    { url = "https://files.pythonhosted.org/packages/93/54/9d7f01fd3fe4069c88827728646e3c8f1aff0995e8422d841b38f034f39a/Pillow-9.5.0-cp310-cp310-win32.whl", hash = "sha256:8507eda3cd0608a1f94f58c64817e83ec12fa93a9436938b191b80d9e4c0fc44", size = 2211916 },
-    { url = "https://files.pythonhosted.org/packages/3e/14/0030e542f2acfea43635e55584c114e6cfd94d342393a5f71f74c172dc35/Pillow-9.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:d3c6b54e304c60c4181da1c9dadf83e4a54fd266a99c70ba646a9baa626819eb", size = 2511474 },
-    { url = "https://files.pythonhosted.org/packages/78/a8/3c2d737d856eb9cd8c18e78f6fe0ed08a2805bded74cbb0455584859023b/Pillow-9.5.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:7ec6f6ce99dab90b52da21cf0dc519e21095e332ff3b399a357c187b1a5eee32", size = 3395792 },
-    { url = "https://files.pythonhosted.org/packages/a9/15/310cde63cb15a091de889ded26281924cf9cfa5c000b36b06bd0c7f50261/Pillow-9.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:560737e70cb9c6255d6dcba3de6578a9e2ec4b573659943a5e7e4af13f298f5c", size = 3077092 },
-    { url = "https://files.pythonhosted.org/packages/17/66/20db69c0361902a2f6ee2086d3e83c70133e3fb4cb31470e59a8ed37184e/Pillow-9.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96e88745a55b88a7c64fa49bceff363a1a27d9a64e04019c2281049444a571e3", size = 3112543 },
-    { url = "https://files.pythonhosted.org/packages/5c/a8/ff526cdec6b56eb20c992e7083f02c8065049ed1e62fbc159390d7a3dd5e/Pillow-9.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d9c206c29b46cfd343ea7cdfe1232443072bbb270d6a46f59c259460db76779a", size = 3386654 },
-    { url = "https://files.pythonhosted.org/packages/3b/70/e9a45a2e9c58c23e023fcda5af9686f5b42c718cc9bc86194e0025cf0ec5/Pillow-9.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cfcc2c53c06f2ccb8976fb5c71d448bdd0a07d26d8e07e321c103416444c7ad1", size = 3308566 },
-    { url = "https://files.pythonhosted.org/packages/61/a5/ee306d6cc53c9a30c23ba2313b43b67fdf76c611ca5afd0cdd62922cbd3e/Pillow-9.5.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a0f9bb6c80e6efcde93ffc51256d5cfb2155ff8f78292f074f60f9e70b942d99", size = 3164027 },
-    { url = "https://files.pythonhosted.org/packages/3d/59/e6bd2c3715ace343d9739276ceed79657fe116923238d102cf731ab463dd/Pillow-9.5.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8d935f924bbab8f0a9a28404422da8af4904e36d5c33fc6f677e4c4485515625", size = 3415610 },
-    { url = "https://files.pythonhosted.org/packages/9a/6d/9beb596ba5a5e61081c843187bcdbb42a5c9a9ef552751b554894247da7a/Pillow-9.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:fed1e1cf6a42577953abbe8e6cf2fe2f566daebde7c34724ec8803c4c0cda579", size = 3350704 },
-    { url = "https://files.pythonhosted.org/packages/1e/e4/de633d85be3b3c770c554a37a89e8273069bd19c34b15a419c2795600310/Pillow-9.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c1170d6b195555644f0616fd6ed929dfcf6333b8675fcca044ae5ab110ded296", size = 3414604 },
-    { url = "https://files.pythonhosted.org/packages/46/a0/e410f655300932308e70e883dd60c0c51e6f74bed138641ea9193e64fd7c/Pillow-9.5.0-cp311-cp311-win32.whl", hash = "sha256:54f7102ad31a3de5666827526e248c3530b3a33539dbda27c6843d19d72644ec", size = 2211929 },
-    { url = "https://files.pythonhosted.org/packages/0c/02/7729c8aecbc525b560c7eb283ffa34c6f5a6d0ed6d1339570c65a3e63088/Pillow-9.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:cfa4561277f677ecf651e2b22dc43e8f5368b74a25a8f7d1d4a3a243e573f2d4", size = 2511551 },
-    { url = "https://files.pythonhosted.org/packages/b9/8b/d38cc68796be4ac238db327682a1acfbc5deccf64a150aa44ee1efbaafae/Pillow-9.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:965e4a05ef364e7b973dd17fc765f42233415974d773e82144c9bbaaaea5d089", size = 2489206 },
-    { url = "https://files.pythonhosted.org/packages/5d/38/b7bcbab3bfe1946ba9cf71c1fa03e541b498069457be49eadcdc229412ef/Pillow-9.5.0-cp312-cp312-win32.whl", hash = "sha256:22baf0c3cf0c7f26e82d6e1adf118027afb325e703922c8dfc1d5d0156bb2eeb", size = 2211914 },
-    { url = "https://files.pythonhosted.org/packages/29/8a/f4cf3f32bc554f9260b645ea1151449ac13525796d3d1a42076d75945d8d/Pillow-9.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:432b975c009cf649420615388561c0ce7cc31ce9b2e374db659ee4f7d57a1f8b", size = 2511483 },
+    { url = "https://files.pythonhosted.org/packages/98/fb/a6ce6836bd7fd93fbf9144bf54789e02babc27403b50a9e1583ee877d6da/pillow-11.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6619654954dc4936fcff82db8eb6401d3159ec6be81e33c6000dfd76ae189947", size = 3154708 },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/1f51e6e912d8ff316bb3935a8cda617c801783e0b998bf7a894e91d3bd4c/pillow-11.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b3c5ac4bed7519088103d9450a1107f76308ecf91d6dabc8a33a2fcfb18d0fba", size = 2979223 },
+    { url = "https://files.pythonhosted.org/packages/90/83/e2077b0192ca8a9ef794dbb74700c7e48384706467067976c2a95a0f40a1/pillow-11.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a65149d8ada1055029fcb665452b2814fe7d7082fcb0c5bed6db851cb69b2086", size = 4183167 },
+    { url = "https://files.pythonhosted.org/packages/0e/74/467af0146970a98349cdf39e9b79a6cc8a2e7558f2c01c28a7b6b85c5bda/pillow-11.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88a58d8ac0cc0e7f3a014509f0455248a76629ca9b604eca7dc5927cc593c5e9", size = 4283912 },
+    { url = "https://files.pythonhosted.org/packages/85/b1/d95d4f7ca3a6c1ae120959605875a31a3c209c4e50f0029dc1a87566cf46/pillow-11.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c26845094b1af3c91852745ae78e3ea47abf3dbcd1cf962f16b9a5fbe3ee8488", size = 4195815 },
+    { url = "https://files.pythonhosted.org/packages/41/c3/94f33af0762ed76b5a237c5797e088aa57f2b7fa8ee7932d399087be66a8/pillow-11.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1a61b54f87ab5786b8479f81c4b11f4d61702830354520837f8cc791ebba0f5f", size = 4366117 },
+    { url = "https://files.pythonhosted.org/packages/ba/3c/443e7ef01f597497268899e1cca95c0de947c9bbf77a8f18b3c126681e5d/pillow-11.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:674629ff60030d144b7bca2b8330225a9b11c482ed408813924619c6f302fdbb", size = 4278607 },
+    { url = "https://files.pythonhosted.org/packages/26/95/1495304448b0081e60c0c5d63f928ef48bb290acee7385804426fa395a21/pillow-11.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:598b4e238f13276e0008299bd2482003f48158e2b11826862b1eb2ad7c768b97", size = 4410685 },
+    { url = "https://files.pythonhosted.org/packages/45/da/861e1df971ef0de9870720cb309ca4d553b26a9483ec9be3a7bf1de4a095/pillow-11.0.0-cp310-cp310-win32.whl", hash = "sha256:9a0f748eaa434a41fccf8e1ee7a3eed68af1b690e75328fd7a60af123c193b50", size = 2249185 },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/78f7c5202ea2a772a5ab05069c1b82503e6353cd79c7e474d4945f4b82c3/pillow-11.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:a5629742881bcbc1f42e840af185fd4d83a5edeb96475a575f4da50d6ede337c", size = 2566726 },
+    { url = "https://files.pythonhosted.org/packages/77/e4/6e84eada35cbcc646fc1870f72ccfd4afacb0fae0c37ffbffe7f5dc24bf1/pillow-11.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:ee217c198f2e41f184f3869f3e485557296d505b5195c513b2bfe0062dc537f1", size = 2254585 },
+    { url = "https://files.pythonhosted.org/packages/f0/eb/f7e21b113dd48a9c97d364e0915b3988c6a0b6207652f5a92372871b7aa4/pillow-11.0.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1c1d72714f429a521d8d2d018badc42414c3077eb187a59579f28e4270b4b0fc", size = 3154705 },
+    { url = "https://files.pythonhosted.org/packages/25/b3/2b54a1d541accebe6bd8b1358b34ceb2c509f51cb7dcda8687362490da5b/pillow-11.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:499c3a1b0d6fc8213519e193796eb1a86a1be4b1877d678b30f83fd979811d1a", size = 2979222 },
+    { url = "https://files.pythonhosted.org/packages/20/12/1a41eddad8265c5c19dda8fb6c269ce15ee25e0b9f8f26286e6202df6693/pillow-11.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8b2351c85d855293a299038e1f89db92a2f35e8d2f783489c6f0b2b5f3fe8a3", size = 4190220 },
+    { url = "https://files.pythonhosted.org/packages/a9/9b/8a8c4d07d77447b7457164b861d18f5a31ae6418ef5c07f6f878fa09039a/pillow-11.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f4dba50cfa56f910241eb7f883c20f1e7b1d8f7d91c750cd0b318bad443f4d5", size = 4291399 },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/130c5fab4a54d3991129800dd2801feeb4b118d7630148cd67f0e6269d4c/pillow-11.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5ddbfd761ee00c12ee1be86c9c0683ecf5bb14c9772ddbd782085779a63dd55b", size = 4202709 },
+    { url = "https://files.pythonhosted.org/packages/39/63/b3fc299528d7df1f678b0666002b37affe6b8751225c3d9c12cf530e73ed/pillow-11.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:45c566eb10b8967d71bf1ab8e4a525e5a93519e29ea071459ce517f6b903d7fa", size = 4372556 },
+    { url = "https://files.pythonhosted.org/packages/c6/a6/694122c55b855b586c26c694937d36bb8d3b09c735ff41b2f315c6e66a10/pillow-11.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b4fd7bd29610a83a8c9b564d457cf5bd92b4e11e79a4ee4716a63c959699b306", size = 4287187 },
+    { url = "https://files.pythonhosted.org/packages/ba/a9/f9d763e2671a8acd53d29b1e284ca298bc10a595527f6be30233cdb9659d/pillow-11.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cb929ca942d0ec4fac404cbf520ee6cac37bf35be479b970c4ffadf2b6a1cad9", size = 4418468 },
+    { url = "https://files.pythonhosted.org/packages/6e/0e/b5cbad2621377f11313a94aeb44ca55a9639adabcaaa073597a1925f8c26/pillow-11.0.0-cp311-cp311-win32.whl", hash = "sha256:006bcdd307cc47ba43e924099a038cbf9591062e6c50e570819743f5607404f5", size = 2249249 },
+    { url = "https://files.pythonhosted.org/packages/dc/83/1470c220a4ff06cd75fc609068f6605e567ea51df70557555c2ab6516b2c/pillow-11.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:52a2d8323a465f84faaba5236567d212c3668f2ab53e1c74c15583cf507a0291", size = 2566769 },
+    { url = "https://files.pythonhosted.org/packages/52/98/def78c3a23acee2bcdb2e52005fb2810ed54305602ec1bfcfab2bda6f49f/pillow-11.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:16095692a253047fe3ec028e951fa4221a1f3ed3d80c397e83541a3037ff67c9", size = 2254611 },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/26e606ff0b2daaf120543e537311fa3ae2eb6bf061490e4fea51771540be/pillow-11.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d2c0a187a92a1cb5ef2c8ed5412dd8d4334272617f532d4ad4de31e0495bd923", size = 3147642 },
+    { url = "https://files.pythonhosted.org/packages/4f/d5/1caabedd8863526a6cfa44ee7a833bd97f945dc1d56824d6d76e11731939/pillow-11.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:084a07ef0821cfe4858fe86652fffac8e187b6ae677e9906e192aafcc1b69903", size = 2978999 },
+    { url = "https://files.pythonhosted.org/packages/d9/ff/5a45000826a1aa1ac6874b3ec5a856474821a1b59d838c4f6ce2ee518fe9/pillow-11.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8069c5179902dcdce0be9bfc8235347fdbac249d23bd90514b7a47a72d9fecf4", size = 4196794 },
+    { url = "https://files.pythonhosted.org/packages/9d/21/84c9f287d17180f26263b5f5c8fb201de0f88b1afddf8a2597a5c9fe787f/pillow-11.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f02541ef64077f22bf4924f225c0fd1248c168f86e4b7abdedd87d6ebaceab0f", size = 4300762 },
+    { url = "https://files.pythonhosted.org/packages/84/39/63fb87cd07cc541438b448b1fed467c4d687ad18aa786a7f8e67b255d1aa/pillow-11.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fcb4621042ac4b7865c179bb972ed0da0218a076dc1820ffc48b1d74c1e37fe9", size = 4210468 },
+    { url = "https://files.pythonhosted.org/packages/7f/42/6e0f2c2d5c60f499aa29be14f860dd4539de322cd8fb84ee01553493fb4d/pillow-11.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:00177a63030d612148e659b55ba99527803288cea7c75fb05766ab7981a8c1b7", size = 4381824 },
+    { url = "https://files.pythonhosted.org/packages/31/69/1ef0fb9d2f8d2d114db982b78ca4eeb9db9a29f7477821e160b8c1253f67/pillow-11.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8853a3bf12afddfdf15f57c4b02d7ded92c7a75a5d7331d19f4f9572a89c17e6", size = 4296436 },
+    { url = "https://files.pythonhosted.org/packages/44/ea/dad2818c675c44f6012289a7c4f46068c548768bc6c7f4e8c4ae5bbbc811/pillow-11.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3107c66e43bda25359d5ef446f59c497de2b5ed4c7fdba0894f8d6cf3822dafc", size = 4429714 },
+    { url = "https://files.pythonhosted.org/packages/af/3a/da80224a6eb15bba7a0dcb2346e2b686bb9bf98378c0b4353cd88e62b171/pillow-11.0.0-cp312-cp312-win32.whl", hash = "sha256:86510e3f5eca0ab87429dd77fafc04693195eec7fd6a137c389c3eeb4cfb77c6", size = 2249631 },
+    { url = "https://files.pythonhosted.org/packages/57/97/73f756c338c1d86bb802ee88c3cab015ad7ce4b838f8a24f16b676b1ac7c/pillow-11.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:8ec4a89295cd6cd4d1058a5e6aec6bf51e0eaaf9714774e1bfac7cfc9051db47", size = 2567533 },
+    { url = "https://files.pythonhosted.org/packages/0b/30/2b61876e2722374558b871dfbfcbe4e406626d63f4f6ed92e9c8e24cac37/pillow-11.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:27a7860107500d813fcd203b4ea19b04babe79448268403172782754870dac25", size = 2254890 },
+    { url = "https://files.pythonhosted.org/packages/63/24/e2e15e392d00fcf4215907465d8ec2a2f23bcec1481a8ebe4ae760459995/pillow-11.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bcd1fb5bb7b07f64c15618c89efcc2cfa3e95f0e3bcdbaf4642509de1942a699", size = 3147300 },
+    { url = "https://files.pythonhosted.org/packages/43/72/92ad4afaa2afc233dc44184adff289c2e77e8cd916b3ddb72ac69495bda3/pillow-11.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0e038b0745997c7dcaae350d35859c9715c71e92ffb7e0f4a8e8a16732150f38", size = 2978742 },
+    { url = "https://files.pythonhosted.org/packages/9e/da/c8d69c5bc85d72a8523fe862f05ababdc52c0a755cfe3d362656bb86552b/pillow-11.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ae08bd8ffc41aebf578c2af2f9d8749d91f448b3bfd41d7d9ff573d74f2a6b2", size = 4194349 },
+    { url = "https://files.pythonhosted.org/packages/cd/e8/686d0caeed6b998351d57796496a70185376ed9c8ec7d99e1d19ad591fc6/pillow-11.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d69bfd8ec3219ae71bcde1f942b728903cad25fafe3100ba2258b973bd2bc1b2", size = 4298714 },
+    { url = "https://files.pythonhosted.org/packages/ec/da/430015cec620d622f06854be67fd2f6721f52fc17fca8ac34b32e2d60739/pillow-11.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:61b887f9ddba63ddf62fd02a3ba7add935d053b6dd7d58998c630e6dbade8527", size = 4208514 },
+    { url = "https://files.pythonhosted.org/packages/44/ae/7e4f6662a9b1cb5f92b9cc9cab8321c381ffbee309210940e57432a4063a/pillow-11.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c6a660307ca9d4867caa8d9ca2c2658ab685de83792d1876274991adec7b93fa", size = 4380055 },
+    { url = "https://files.pythonhosted.org/packages/74/d5/1a807779ac8a0eeed57f2b92a3c32ea1b696e6140c15bd42eaf908a261cd/pillow-11.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:73e3a0200cdda995c7e43dd47436c1548f87a30bb27fb871f352a22ab8dcf45f", size = 4296751 },
+    { url = "https://files.pythonhosted.org/packages/38/8c/5fa3385163ee7080bc13026d59656267daaaaf3c728c233d530e2c2757c8/pillow-11.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fba162b8872d30fea8c52b258a542c5dfd7b235fb5cb352240c8d63b414013eb", size = 4430378 },
+    { url = "https://files.pythonhosted.org/packages/ca/1d/ad9c14811133977ff87035bf426875b93097fb50af747793f013979facdb/pillow-11.0.0-cp313-cp313-win32.whl", hash = "sha256:f1b82c27e89fffc6da125d5eb0ca6e68017faf5efc078128cfaa42cf5cb38798", size = 2249588 },
+    { url = "https://files.pythonhosted.org/packages/fb/01/3755ba287dac715e6afdb333cb1f6d69740a7475220b4637b5ce3d78cec2/pillow-11.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ba470552b48e5835f1d23ecb936bb7f71d206f9dfeee64245f30c3270b994de", size = 2567509 },
+    { url = "https://files.pythonhosted.org/packages/c0/98/2c7d727079b6be1aba82d195767d35fcc2d32204c7a5820f822df5330152/pillow-11.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:846e193e103b41e984ac921b335df59195356ce3f71dcfd155aa79c603873b84", size = 2254791 },
+    { url = "https://files.pythonhosted.org/packages/eb/38/998b04cc6f474e78b563716b20eecf42a2fa16a84589d23c8898e64b0ffd/pillow-11.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4ad70c4214f67d7466bea6a08061eba35c01b1b89eaa098040a35272a8efb22b", size = 3150854 },
+    { url = "https://files.pythonhosted.org/packages/13/8e/be23a96292113c6cb26b2aa3c8b3681ec62b44ed5c2bd0b258bd59503d3c/pillow-11.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6ec0d5af64f2e3d64a165f490d96368bb5dea8b8f9ad04487f9ab60dc4bb6003", size = 2982369 },
+    { url = "https://files.pythonhosted.org/packages/97/8a/3db4eaabb7a2ae8203cd3a332a005e4aba00067fc514aaaf3e9721be31f1/pillow-11.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c809a70e43c7977c4a42aefd62f0131823ebf7dd73556fa5d5950f5b354087e2", size = 4333703 },
+    { url = "https://files.pythonhosted.org/packages/28/ac/629ffc84ff67b9228fe87a97272ab125bbd4dc462745f35f192d37b822f1/pillow-11.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4b60c9520f7207aaf2e1d94de026682fc227806c6e1f55bba7606d1c94dd623a", size = 4412550 },
+    { url = "https://files.pythonhosted.org/packages/d6/07/a505921d36bb2df6868806eaf56ef58699c16c388e378b0dcdb6e5b2fb36/pillow-11.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1e2688958a840c822279fda0086fec1fdab2f95bf2b717b66871c4ad9859d7e8", size = 4461038 },
+    { url = "https://files.pythonhosted.org/packages/d6/b9/fb620dd47fc7cc9678af8f8bd8c772034ca4977237049287e99dda360b66/pillow-11.0.0-cp313-cp313t-win32.whl", hash = "sha256:607bbe123c74e272e381a8d1957083a9463401f7bd01287f50521ecb05a313f8", size = 2253197 },
+    { url = "https://files.pythonhosted.org/packages/df/86/25dde85c06c89d7fc5db17940f07aae0a56ac69aa9ccb5eb0f09798862a8/pillow-11.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5c39ed17edea3bc69c743a8dd3e9853b7509625c2462532e62baa0732163a904", size = 2572169 },
+    { url = "https://files.pythonhosted.org/packages/51/85/9c33f2517add612e17f3381aee7c4072779130c634921a756c97bc29fb49/pillow-11.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:75acbbeb05b86bc53cbe7b7e6fe00fbcf82ad7c684b3ad82e3d711da9ba287d3", size = 2256828 },
+    { url = "https://files.pythonhosted.org/packages/36/57/42a4dd825eab762ba9e690d696d894ba366e06791936056e26e099398cda/pillow-11.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1187739620f2b365de756ce086fdb3604573337cc28a0d3ac4a01ab6b2d2a6d2", size = 3119239 },
+    { url = "https://files.pythonhosted.org/packages/98/f7/25f9f9e368226a1d6cf3507081a1a7944eddd3ca7821023377043f5a83c8/pillow-11.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbbcb7b57dc9c794843e3d1258c0fbf0f48656d46ffe9e09b63bbd6e8cd5d0a2", size = 2950803 },
+    { url = "https://files.pythonhosted.org/packages/59/01/98ead48a6c2e31e6185d4c16c978a67fe3ccb5da5c2ff2ba8475379bb693/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d203af30149ae339ad1b4f710d9844ed8796e97fda23ffbc4cc472968a47d0b", size = 3281098 },
+    { url = "https://files.pythonhosted.org/packages/51/c0/570255b2866a0e4d500a14f950803a2ec273bac7badc43320120b9262450/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21a0d3b115009ebb8ac3d2ebec5c2982cc693da935f4ab7bb5c8ebe2f47d36f2", size = 3323665 },
+    { url = "https://files.pythonhosted.org/packages/0e/75/689b4ec0483c42bfc7d1aacd32ade7a226db4f4fac57c6fdcdf90c0731e3/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:73853108f56df97baf2bb8b522f3578221e56f646ba345a372c78326710d3830", size = 3310533 },
+    { url = "https://files.pythonhosted.org/packages/3d/30/38bd6149cf53da1db4bad304c543ade775d225961c4310f30425995cb9ec/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734", size = 3414886 },
+    { url = "https://files.pythonhosted.org/packages/ec/3d/c32a51d848401bd94cabb8767a39621496491ee7cd5199856b77da9b18ad/pillow-11.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:224aaa38177597bb179f3ec87eeefcce8e4f85e608025e9cfac60de237ba6316", size = 2567508 },
 ]
 
 [[package]]
@@ -263,15 +297,15 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/41/e046526849972555928a6d31c2068410e47a31fb5ab0a77f868596811329/pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470", size = 61440 }
+sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/49/b3e0edec68d81846f519c602ac38af9db86e1e71275528b3e814ae236063/pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6", size = 20981 },
+    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
 ]
 
 [[package]]
@@ -382,14 +416,14 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.4" },
     { name = "olefile", specifier = ">=0.46" },
     { name = "omexml-dls", specifier = ">=1.1.0" },
-    { name = "pillow", specifier = ">=5.3,<10.0.0" },
+    { name = "pillow", specifier = ">=11" },
     { name = "pywin32", marker = "platform_system == 'Windows'" },
     { name = "scipy", specifier = ">=1.3.3" },
-    { name = "tifffile", specifier = ">=2020.9.30" },
+    { name = "tifffile", specifier = ">=2022.7.28" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "parameterized", specifier = ">=0.9.0" },
-    { name = "pytest-cov", specifier = ">=3.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/8b/bc4e0dfa1245b07cf14300e10319b98e958a53ff074c1dd86b35253a8c2a/ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2", size = 3275547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/4b/f5094719e254829766b807dadb766841124daba75a37da83e292ae5ad12f/ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478", size = 10447512 },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/3d2d2c9f601cf6044799c5349ff5267467224cefed9b35edf5f1f36486e9/ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63", size = 10235436 },
+    { url = "https://files.pythonhosted.org/packages/62/83/42a6ec6216ded30b354b13e0e9327ef75a3c147751aaf10443756cb690e9/ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20", size = 9888936 },
+    { url = "https://files.pythonhosted.org/packages/4d/26/e1e54893b13046a6ad05ee9b89ee6f71542ba250f72b4c7a7d17c3dbf73d/ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109", size = 10697353 },
+    { url = "https://files.pythonhosted.org/packages/21/24/98d2e109c4efc02bfef144ec6ea2c3e1217e7ce0cfddda8361d268dfd499/ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452", size = 10228078 },
+    { url = "https://files.pythonhosted.org/packages/ad/b7/964c75be9bc2945fc3172241b371197bb6d948cc69e28bc4518448c368f3/ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea", size = 11264823 },
+    { url = "https://files.pythonhosted.org/packages/12/8d/20abdbf705969914ce40988fe71a554a918deaab62c38ec07483e77866f6/ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7", size = 11951855 },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/6519ce58c57b4edafcdf40920b7273dfbba64fc6ebcaae7b88e4dc1bf0a8/ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05", size = 11516580 },
+    { url = "https://files.pythonhosted.org/packages/37/1a/5ec1844e993e376a86eb2456496831ed91b4398c434d8244f89094758940/ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06", size = 12692057 },
+    { url = "https://files.pythonhosted.org/packages/50/90/76867152b0d3c05df29a74bb028413e90f704f0f6701c4801174ba47f959/ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc", size = 11085137 },
+    { url = "https://files.pythonhosted.org/packages/c8/eb/0a7cb6059ac3555243bd026bb21785bbc812f7bbfa95a36c101bd72b47ae/ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172", size = 10681243 },
+    { url = "https://files.pythonhosted.org/packages/5e/76/2270719dbee0fd35780b05c08a07b7a726c3da9f67d9ae89ef21fc18e2e5/ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a", size = 10319187 },
+    { url = "https://files.pythonhosted.org/packages/9f/e5/39100f72f8ba70bec1bd329efc880dea8b6c1765ea1cb9d0c1c5f18b8d7f/ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd", size = 10803715 },
+    { url = "https://files.pythonhosted.org/packages/a5/89/40e904784f305fb56850063f70a998a64ebba68796d823dde67e89a24691/ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a", size = 11162912 },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/dd77503b3875c51e3dbc053fd8367b845ab8b01c9ca6d0c237082732856c/ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac", size = 8702767 },
+    { url = "https://files.pythonhosted.org/packages/63/76/253ddc3e89e70165bba952ecca424b980b8d3c2598ceb4fc47904f424953/ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6", size = 9497534 },
+    { url = "https://files.pythonhosted.org/packages/aa/70/f8724f31abc0b329ca98b33d73c14020168babcf71b0cba3cded5d9d0e66/ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f", size = 8851590 },
+]
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +434,7 @@ dependencies = [
 dev = [
     { name = "parameterized" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -452,4 +452,5 @@ requires-dist = [
 dev = [
     { name = "parameterized", specifier = ">=0.9.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.7.4" },
 ]


### PR DESCRIPTION
Updates dependencies:
- `pillow >=5.3, <10.0.0` to `pillow >=11`
- `tifffile >=2020.9.30` to `tifffile >=2022.7.28`

There previously was an issue with pillow 10 causing some tests to fail due to a lack of text. However, this seems to be a change in how a font size of 0 was handled (something that could happen with the tiny arrays used in the tests), where I guess it must have rounded to 1 before but now raises an error. Using `math.ceil` fixes this.

I was getting deprecation warnings around the use of `tifffile.TIFF.RESUNIT` saying to use `tifffile.RESUNIT` instead. I've set the new minimum version of tifffile to the version that introduced this deprecation.

coverage was hitting deprecation warnings from pytest, so I've bumped it up to 6.0