### PR TITLE
Only upload artifacts if it is a tag push

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
       - name: Upload sdist and wheel as artifacts
+        # no need to store artifacts unless publishing them
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: actions/upload-artifact@v4
         with:
           name: dist


### PR DESCRIPTION
Skips uploading artifacts that won't be used for publishing