### PR TITLE
Fix workflow job pypi-publish

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,5 +65,3 @@ jobs:
       # publish to PyPI using trusted publishing
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     # Specify the GitHub Environment to publish to
     environment:
-      name: pypi
+      name: release
       url: https://pypi.org/p/txrm2tiff
     # upload to PyPI and make a release on every tag
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,3 +65,5 @@ jobs:
       # publish to PyPI using trusted publishing
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false


### PR DESCRIPTION
https://github.com/DiamondLightSource/txrm2tiff/actions/runs/11935095277/job/33265786251 has the error:
```
Error: Trusted publishing exchange failure: 
Token request failed: the server refused the request for the following reasons:

* `invalid-publisher`: valid token, but no corresponding publisher (All lookup strategies exhausted)

This generally indicates a trusted publisher configuration error, but could
also indicate an internal error on GitHub or PyPI's part.


The claims rendered below are **for debugging purposes only**. You should **not**
use them to configure a trusted publisher unless they already match your expectations.

If a claim is not present in the claim set, then it is rendered as `MISSING`.

* `sub`: `repo:DiamondLightSource/txrm2tiff:environment:pypi`
* `repository`: `DiamondLightSource/txrm2tiff`
* `repository_owner`: `DiamondLightSource`
* `repository_owner_id`: `1233618`
* `job_workflow_ref`: `DiamondLightSource/txrm2tiff/.github/workflows/python-package.yml@refs/tags/v2.2.0`
* `ref`: `refs/tags/v2.2.0`
```

I suspect this is due to removing `attestations: false`.