### PR TITLE
Fixes for applying external references

### DIFF
--- a/src/txrm2tiff/txrm/abstract.py
+++ b/src/txrm2tiff/txrm/abstract.py
@@ -342,7 +342,7 @@ class AbstractTxrm(ABC):
         shape = self._images.shape
         if len(shape) > 2:
             shape = self._images[0].shape
-        return shape
+        return list(shape)
 
     @txrm_property(fallback=dict())
     def image_info(self):

--- a/src/txrm2tiff/txrm/abstract.py
+++ b/src/txrm2tiff/txrm/abstract.py
@@ -341,7 +341,7 @@ class AbstractTxrm(ABC):
             return [self.image_info["ImageHeight"][0], self.image_info["ImageWidth"][0]]
         shape = self._images.shape
         if len(shape) > 2:
-            shape = self._image[0].shape
+            shape = self._images[0].shape
         return shape
 
     @txrm_property(fallback=dict())

--- a/src/txrm2tiff/txrm/ref_mixin.py
+++ b/src/txrm2tiff/txrm/ref_mixin.py
@@ -110,7 +110,7 @@ class ReferenceMixin:
         """Applies image(s) to txrm image(s), returning the images as a numpy ndarray and overwrites the txrm image(s) if overwrite is True."""
         self.apply_custom_reference_from_array(
             txrm.get_images(load=True)[0],
-            compensate_exposure,
+            np.mean(txrm.exposures) if compensate_exposure else None,
             overwrite,
         )
 
@@ -145,7 +145,7 @@ class ReferenceMixin:
             round(img_dim / mos_dim, 2)
             for img_dim, mos_dim in zip(self.shape, self.mosaic_dims[::-1])
         ]  # True if it's a mosaic and the correct dims to be tiled to mosaic
-        assert list(custom_reference.shape) == list(self.shape) or needs_stitching, (
+        assert list(custom_reference.shape) == self.shape or needs_stitching, (
             "Invalid reference shape for %s" % self.name
         )
         # Checks that reference is either the size of the image or can be stitched to that size

--- a/src/txrm2tiff/txrm/ref_mixin.py
+++ b/src/txrm2tiff/txrm/ref_mixin.py
@@ -109,8 +109,7 @@ class ReferenceMixin:
     ) -> np.ndarray:
         """Applies image(s) to txrm image(s), returning the images as a numpy ndarray and overwrites the txrm image(s) if overwrite is True."""
         self.apply_custom_reference_from_array(
-            txrm.get_images(load=True),
-            np.mean(txrm.exposures),
+            txrm.get_images(load=True)[0],
             compensate_exposure,
             overwrite,
         )
@@ -146,7 +145,7 @@ class ReferenceMixin:
             round(img_dim / mos_dim, 2)
             for img_dim, mos_dim in zip(self.shape, self.mosaic_dims[::-1])
         ]  # True if it's a mosaic and the correct dims to be tiled to mosaic
-        assert custom_reference.shape == self.shape or needs_stitching, (
+        assert list(custom_reference.shape) == self.shape or needs_stitching, (
             "Invalid reference shape for %s" % self.name
         )
         # Checks that reference is either the size of the image or can be stitched to that size

--- a/src/txrm2tiff/txrm/ref_mixin.py
+++ b/src/txrm2tiff/txrm/ref_mixin.py
@@ -145,7 +145,7 @@ class ReferenceMixin:
             round(img_dim / mos_dim, 2)
             for img_dim, mos_dim in zip(self.shape, self.mosaic_dims[::-1])
         ]  # True if it's a mosaic and the correct dims to be tiled to mosaic
-        assert list(custom_reference.shape) == self.shape or needs_stitching, (
+        assert list(custom_reference.shape) == list(self.shape) or needs_stitching, (
             "Invalid reference shape for %s" % self.name
         )
         # Checks that reference is either the size of the image or can be stitched to that size

--- a/src/txrm2tiff/txrm/ref_mixin.py
+++ b/src/txrm2tiff/txrm/ref_mixin.py
@@ -84,7 +84,7 @@ class ReferenceMixin:
             )
         try:
             ref_img = ReferenceMixin._flatten_reference(custom_reference)
-            ref_img = self._tile_reference_if_needed(custom_reference)
+            ref_img = self._tile_reference_if_needed(ref_img)
         except Exception:
             if self.strict:
                 raise


### PR DESCRIPTION
A few bugs discovered when using the txrm conversion with an external reference applied:

- `apply_custom_reference_from_array` only takes 3 parameters in addition to self, but 4 were provided for external references
- The custom reference shape is a tuple, but the `self.shape` attribute is typed as a list. I have list converted both to avoid ambiguity and ensure the assertion works.
- The `self._image` attribute does not appear to exist, it should be named `self._images`